### PR TITLE
test: add initial tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,5 +16,6 @@ module.exports = {
     'sourceType': 'module',
   },
   'rules': {
+    "require-jsdoc": ['warn']
   },
 };

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: Node.js CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - run: npm install
+      - run: npm run build --if-present
+      - run: npm test
+        env:
+          CI: true
+          AIRTABLE_KEY: keyXXXXXXXXXXXXXXX
+          AIRTABLE_BASE: appXXXXXXXXXXXXXXX
+          AIRTABLE_TABLE_NAME: Individual Needs Requests
+          MANYC_NEW_REQ: https://hook.integromat.com/xxxxxxxxxxxxxxxxxxxxx
+          MANYC_UPDATE_REQ: REPLACE_ME
+          MANYC_DELETE_REQ_URL: REPLACE_ME
+          PORT: 8080

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ node_modules/
 
 *.swp
 .env
+
+# nyc
+coverage/
+.nyc_output

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,174 @@
         "@babel/highlight": "^7.8.3"
       }
     },
+    "@babel/core": {
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.6.tgz",
+      "integrity": "sha512-nD3deLvbsApbHAHttzIssYqgb883yU/d9roe4RZymBCDaZryMJDbptVpEpeQuRh4BJ+SYI8le9YGxKvFEvl1Wg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.8.3",
+        "@babel/generator": "^7.9.6",
+        "@babel/helper-module-transforms": "^7.9.0",
+        "@babel/helpers": "^7.9.6",
+        "@babel/parser": "^7.9.6",
+        "@babel/template": "^7.8.6",
+        "@babel/traverse": "^7.9.6",
+        "@babel/types": "^7.9.6",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.1",
+        "json5": "^2.1.2",
+        "lodash": "^4.17.13",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.6.tgz",
+      "integrity": "sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.9.6",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.13",
+        "source-map": "^0.5.0"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.9.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
+      "integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.8.3",
+        "@babel/template": "^7.8.3",
+        "@babel/types": "^7.9.5"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+      "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
+      "integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
+      "integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
+      "integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.8.3",
+        "@babel/helper-replace-supers": "^7.8.6",
+        "@babel/helper-simple-access": "^7.8.3",
+        "@babel/helper-split-export-declaration": "^7.8.3",
+        "@babel/template": "^7.8.6",
+        "@babel/types": "^7.9.0",
+        "lodash": "^4.17.13"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
+      "integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.9.6.tgz",
+      "integrity": "sha512-qX+chbxkbArLyCImk3bWV+jB5gTNU/rsze+JlcF6Nf8tVTigPJSI1o1oBow/9Resa1yehUO9lIipsmu9oG4RzA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.8.3",
+        "@babel/helper-optimise-call-expression": "^7.8.3",
+        "@babel/traverse": "^7.9.6",
+        "@babel/types": "^7.9.6"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
+      "integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+      "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
     "@babel/helper-validator-identifier": {
       "version": "7.9.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
       "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==",
       "dev": true
+    },
+    "@babel/helpers": {
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.6.tgz",
+      "integrity": "sha512-tI4bUbldloLcHWoRUMAj4g1bF313M/o6fBKhIsb3QnGVPwRm9JsNf/gqMkQ7zjqReABiffPV6RWj7hEglID5Iw==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.8.3",
+        "@babel/traverse": "^7.9.6",
+        "@babel/types": "^7.9.6"
+      }
     },
     "@babel/highlight": {
       "version": "7.9.0",
@@ -29,6 +192,134 @@
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
+    },
+    "@babel/parser": {
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.6.tgz",
+      "integrity": "sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q==",
+      "dev": true
+    },
+    "@babel/template": {
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+      "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.8.3",
+        "@babel/parser": "^7.8.6",
+        "@babel/types": "^7.8.6"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.6.tgz",
+      "integrity": "sha512-b3rAHSjbxy6VEAvlxM8OV/0X4XrG72zoxme6q1MOoe2vd0bEc+TwayhuC1+Dfgqh1QEG+pj7atQqvUprHIccsg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.8.3",
+        "@babel/generator": "^7.9.6",
+        "@babel/helper-function-name": "^7.9.5",
+        "@babel/helper-split-export-declaration": "^7.8.3",
+        "@babel/parser": "^7.9.6",
+        "@babel/types": "^7.9.6",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.13"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.6.tgz",
+      "integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.9.5",
+        "lodash": "^4.17.13",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@istanbuljs/load-nyc-config": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
+      "integrity": "sha512-ZR0rq/f/E4f4XcgnDvtMWXCUJpi8eO0rssVhmztsZqLIEFA9UUP9zmpE0VxlM+kv/E1ul2I876Fwil2ayptDVg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
+      }
+    },
+    "@istanbuljs/schema": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
+      "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
+      "dev": true
     },
     "@sinonjs/commons": {
       "version": "1.7.2",
@@ -101,6 +392,16 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
       "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
       "dev": true
+    },
+    "aggregate-error": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
+      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+      "dev": true,
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      }
     },
     "airtable": {
       "version": "0.8.1",
@@ -180,6 +481,21 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
+    },
+    "append-transform": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
+      "integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
+      "dev": true,
+      "requires": {
+        "default-require-extensions": "^3.0.0"
+      }
+    },
+    "archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
@@ -310,6 +626,18 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
       "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
     },
+    "caching-transform": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
+      "integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
+      "dev": true,
+      "requires": {
+        "hasha": "^5.0.0",
+        "make-dir": "^3.0.0",
+        "package-hash": "^4.0.0",
+        "write-file-atomic": "^3.0.0"
+      }
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -379,6 +707,12 @@
         "normalize-path": "~3.0.0",
         "readdirp": "~3.2.0"
       }
+    },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true
     },
     "cli-cursor": {
       "version": "3.1.0",
@@ -454,6 +788,12 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -478,6 +818,15 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
+    "convert-source-map": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
     },
     "cookie": {
       "version": "0.4.0",
@@ -557,6 +906,15 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "default-require-extensions": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.0.tgz",
+      "integrity": "sha512-ek6DpXq/SCpvjhpFsLFRVtIxJCRw6fUR42lYMVZuUMK7n8eMz4Uh5clckdBjEpLhn/gEBZo7hDJnJcwdKLKQjg==",
+      "dev": true,
+      "requires": {
+        "strip-bom": "^4.0.0"
+      }
     },
     "define-properties": {
       "version": "1.1.3",
@@ -662,6 +1020,12 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true
     },
     "es6-promise": {
       "version": "4.2.8",
@@ -947,6 +1311,17 @@
         "unpipe": "~1.0.0"
       }
     },
+    "find-cache-dir": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+      "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+      "dev": true,
+      "requires": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      }
+    },
     "find-up": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -1000,6 +1375,59 @@
         }
       }
     },
+    "foreground-child": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+      "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
+          "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -1031,6 +1459,12 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
+    "fromentries": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.2.0.tgz",
+      "integrity": "sha512-33X7H/wdfO99GdRLLgkjUrD4geAFdq/Uv0kl3HD4da6HDixd2GUg8Mw7dahLCV9r/EARkmtYBB6Tch4EEokFTQ==",
+      "dev": true
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1054,6 +1488,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "gensync": {
+      "version": "1.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+      "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
       "dev": true
     },
     "get-caller-file": {
@@ -1117,6 +1557,12 @@
         "type-fest": "^0.8.1"
       }
     },
+    "graceful-fs": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+      "dev": true
+    },
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
@@ -1158,10 +1604,26 @@
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
       "dev": true
     },
+    "hasha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.0.tgz",
+      "integrity": "sha512-2W+jKdQbAdSIrggA8Q35Br8qKadTrqCTC8+XZvBWepKDK6m9XkX6Iz1a2yh2KP01kzAR/dpuMeUnocoLYDcskw==",
+      "dev": true,
+      "requires": {
+        "is-stream": "^2.0.0",
+        "type-fest": "^0.8.0"
+      }
+    },
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
+    "html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
     "http-errors": {
@@ -1214,6 +1676,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true
     },
     "inflight": {
@@ -1392,6 +1860,12 @@
         "has": "^1.0.3"
       }
     },
+    "is-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+      "dev": true
+    },
     "is-symbol": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
@@ -1405,6 +1879,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
     },
     "isarray": {
       "version": "0.0.1",
@@ -1422,6 +1902,172 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "istanbul-lib-coverage": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+      "dev": true
+    },
+    "istanbul-lib-hook": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
+      "integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
+      "dev": true,
+      "requires": {
+        "append-transform": "^2.0.0"
+      }
+    },
+    "istanbul-lib-instrument": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+      "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.7.5",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.0.0",
+        "semver": "^6.3.0"
+      }
+    },
+    "istanbul-lib-processinfo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
+      "integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
+      "dev": true,
+      "requires": {
+        "archy": "^1.0.0",
+        "cross-spawn": "^7.0.0",
+        "istanbul-lib-coverage": "^3.0.0-alpha.1",
+        "make-dir": "^3.0.0",
+        "p-map": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "uuid": "^3.3.3"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
+          "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+      "dev": true,
+      "requires": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^3.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-lib-source-maps": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
+      "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "istanbul-reports": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+      "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+      "dev": true,
+      "requires": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      }
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -1444,6 +2090,12 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -1464,6 +2116,15 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "json5": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
     },
     "jsprim": {
       "version": "1.4.1",
@@ -1507,6 +2168,12 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
+    "lodash.flattendeep": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -1520,6 +2187,15 @@
       "dev": true,
       "requires": {
         "chalk": "^2.4.2"
+      }
+    },
+    "make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "requires": {
+        "semver": "^6.0.0"
       }
     },
     "media-typer": {
@@ -1741,11 +2417,190 @@
         }
       }
     },
+    "node-preload": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
+      "integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
+      "dev": true,
+      "requires": {
+        "process-on-spawn": "^1.0.0"
+      }
+    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
+    },
+    "nyc": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.0.1.tgz",
+      "integrity": "sha512-n0MBXYBYRqa67IVt62qW1r/d9UH/Qtr7SF1w/nQLJ9KxvWF6b2xCHImRAixHN9tnMMYHC2P14uo6KddNGwMgGg==",
+      "dev": true,
+      "requires": {
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "caching-transform": "^4.0.0",
+        "convert-source-map": "^1.7.0",
+        "decamelize": "^1.2.0",
+        "find-cache-dir": "^3.2.0",
+        "find-up": "^4.1.0",
+        "foreground-child": "^2.0.0",
+        "glob": "^7.1.6",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-hook": "^3.0.0",
+        "istanbul-lib-instrument": "^4.0.0",
+        "istanbul-lib-processinfo": "^2.0.2",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.0.2",
+        "make-dir": "^3.0.0",
+        "node-preload": "^0.2.1",
+        "p-map": "^3.0.0",
+        "process-on-spawn": "^1.0.0",
+        "resolve-from": "^5.0.0",
+        "rimraf": "^3.0.0",
+        "signal-exit": "^3.0.2",
+        "spawn-wrap": "^2.0.0",
+        "test-exclude": "^6.0.0",
+        "yargs": "^15.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "yargs": {
+          "version": "15.3.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
+          "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
+          "dev": true,
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -1850,11 +2705,32 @@
         "p-limit": "^2.0.0"
       }
     },
+    "p-map": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+      "dev": true,
+      "requires": {
+        "aggregate-error": "^3.0.0"
+      }
+    },
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
+    },
+    "package-hash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
+      "integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.15",
+        "hasha": "^5.0.0",
+        "lodash.flattendeep": "^4.4.0",
+        "release-zalgo": "^1.0.0"
+      }
     },
     "parent-module": {
       "version": "1.0.1",
@@ -1893,6 +2769,12 @@
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -1915,6 +2797,51 @@
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
     },
+    "pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        }
+      }
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -1931,6 +2858,15 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
+    },
+    "process-on-spawn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
+      "integrity": "sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==",
+      "dev": true,
+      "requires": {
+        "fromentries": "^1.2.0"
+      }
     },
     "progress": {
       "version": "2.0.3",
@@ -2016,6 +2952,15 @@
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
     },
+    "release-zalgo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+      "dev": true,
+      "requires": {
+        "es6-error": "^4.0.1"
+      }
+    },
     "request": {
       "version": "2.88.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
@@ -2061,6 +3006,15 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
+    },
+    "resolve": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
     },
     "resolve-from": {
       "version": "4.0.0",
@@ -2248,6 +3202,46 @@
         }
       }
     },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "spawn-wrap": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
+      "integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
+      "dev": true,
+      "requires": {
+        "foreground-child": "^2.0.0",
+        "is-windows": "^1.0.2",
+        "make-dir": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "signal-exit": "^3.0.2",
+        "which": "^2.0.1"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -2365,6 +3359,12 @@
         }
       }
     },
+    "strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "dev": true
+    },
     "strip-json-comments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
@@ -2462,6 +3462,17 @@
         }
       }
     },
+    "test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "requires": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -2482,6 +3493,12 @@
       "requires": {
         "os-tmpdir": "~1.0.2"
       }
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -2560,6 +3577,15 @@
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
+      }
+    },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "requires": {
+        "is-typedarray": "^1.0.0"
       }
     },
     "unpipe": {
@@ -2724,6 +3750,18 @@
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
+      }
+    },
+    "write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "dev": true,
+      "requires": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
       }
     },
     "xhr": {

--- a/package.json
+++ b/package.json
@@ -16,13 +16,15 @@
         "eslint": "^6.8.0",
         "eslint-config-google": "^0.14.0",
         "mocha": "^7.1.2",
+        "nyc": "^15.0.1",
         "sinon": "^9.0.2",
         "supertest": "^4.0.2"
     },
     "scripts": {
         "start": "node src/app.js",
         "test": "mocha --recursive",
-        "lint": "eslint ."
+        "lint": "eslint .",
+        "coverage": "nyc --reporter=text --reporter=html mocha --recursive --exit --timeout 15000 && open coverage/index.html"
     },
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "start": "node src/app.js",
         "test": "mocha --recursive",
         "lint": "eslint .",
+        "lint-fix": "eslint . --fix",
         "coverage": "nyc --reporter=text --reporter=html mocha --recursive --exit --timeout 15000 && open coverage/index.html"
     },
     "repository": {

--- a/src/loaders/index.js
+++ b/src/loaders/index.js
@@ -5,5 +5,5 @@ const airtablePoller = require('../service/airtablePoller');
 module.exports = (app) => {
   expressLoader(app);
   console.log('Express Loaded!');
-  airtablePoller();
+  airtablePoller.poll();
 };

--- a/src/routes/api/createRequest.js
+++ b/src/routes/api/createRequest.js
@@ -1,11 +1,12 @@
 'use strict';
 const airtableHelper = require('../../service/addAirTableRow');
+const config = require('../../config');
 
 module.exports = (app) => {
   app.post('/createRequest', async function(req, res) {
     const newRequest = req.body;
     try {
-      await airtableHelper(
+      await airtableHelper.addAirtableRows(
           config.airtable.key,
           config.airtable.baseId,
           config.airtable.tableName,

--- a/src/routes/api/setColumnMapping.js
+++ b/src/routes/api/setColumnMapping.js
@@ -2,7 +2,7 @@
 
 module.exports = (app) => {
   app.post('/setColumnMapping', function(req, res) {
-    clientColumnMapping = {
+    const clientColumnMapping = {
       status: req.body.status,
       id: req.body.id,
       supportType: req.body.supportType,
@@ -21,7 +21,7 @@ module.exports = (app) => {
       source: req.body.source,
       sourceID: req.body.sourceID,
     };
-    console.log(clientMapping);
+    console.log(clientColumnMapping);
     res.send('MANYC Airtable-Gateway Client Mapping Set');
   });
 };

--- a/src/service/addAirTableRow.js
+++ b/src/service/addAirTableRow.js
@@ -108,4 +108,4 @@ const addAirtableRows = (
   return createRecords(transformedRecords);
 };
 
-module.exports = addAirtableRows;
+module.exports = {addAirtableRows};

--- a/src/service/airtablePoller.js
+++ b/src/service/airtablePoller.js
@@ -7,16 +7,16 @@ const config = require('../config');
 
 class AirtablePoller {
   constructor() {
-    const base = new Airtable({apiKey: config.airtable.key})
-        .base(config.airtable.baseId);
+    const base = new Airtable({ apiKey: config.airtable.key })
+      .base(config.airtable.baseId);
 
     this.airtableGatewayDetector = new ChangeDetector(
-        base(config.airtable.tableName), {
-          writeDelayMs: 100,
-          metaFieldName: 'Meta', // Defaults to `Meta`
-          lastModifiedFieldName: 'AirTable Gateway Last Modified',
-          lastProcessedFieldName: 'Airtable Gateway Last Processed',
-        },
+      base(config.airtable.tableName), {
+      writeDelayMs: 100,
+      metaFieldName: 'Meta', // Defaults to `Meta`
+      lastModifiedFieldName: 'AirTable Gateway Last Modified',
+      lastProcessedFieldName: 'Airtable Gateway Last Processed',
+    },
     );
   }
   async processChangedRecords(recordsChanged) {
@@ -48,6 +48,7 @@ class AirtablePoller {
       } else if (assignedArr.includes(record.fields.Status)) {
         status = 'assigned';
       } else {
+        console.log('returned')
         return;
       }
       promises.push(axios.post(config.url.newReq, {
@@ -66,9 +67,9 @@ class AirtablePoller {
   }
   poll() {
     this.airtableGatewayDetector.pollWithInterval(
-        `Polling of ${config.airtable.tableName}`,
-        10000, // interval in milliseconds
-        this.processChangedRecords);
+      `Polling of ${config.airtable.tableName}`,
+      10000, // interval in milliseconds
+      this.processChangedRecords);
   }
 }
 

--- a/src/service/airtablePoller.js
+++ b/src/service/airtablePoller.js
@@ -7,16 +7,16 @@ const config = require('../config');
 
 class AirtablePoller {
   constructor() {
-    const base = new Airtable({ apiKey: config.airtable.key })
-      .base(config.airtable.baseId);
+    const base = new Airtable({apiKey: config.airtable.key})
+        .base(config.airtable.baseId);
 
     this.airtableGatewayDetector = new ChangeDetector(
-      base(config.airtable.tableName), {
-      writeDelayMs: 100,
-      metaFieldName: 'Meta', // Defaults to `Meta`
-      lastModifiedFieldName: 'AirTable Gateway Last Modified',
-      lastProcessedFieldName: 'Airtable Gateway Last Processed',
-    },
+        base(config.airtable.tableName), {
+          writeDelayMs: 100,
+          metaFieldName: 'Meta', // Defaults to `Meta`
+          lastModifiedFieldName: 'AirTable Gateway Last Modified',
+          lastProcessedFieldName: 'Airtable Gateway Last Processed',
+        },
     );
   }
   async processChangedRecords(recordsChanged) {
@@ -48,7 +48,7 @@ class AirtablePoller {
       } else if (assignedArr.includes(record.fields.Status)) {
         status = 'assigned';
       } else {
-        console.log('returned')
+        console.log('returned');
         return;
       }
       promises.push(axios.post(config.url.newReq, {
@@ -67,9 +67,9 @@ class AirtablePoller {
   }
   poll() {
     this.airtableGatewayDetector.pollWithInterval(
-      `Polling of ${config.airtable.tableName}`,
-      10000, // interval in milliseconds
-      this.processChangedRecords);
+        `Polling of ${config.airtable.tableName}`,
+        10000, // interval in milliseconds
+        this.processChangedRecords);
   }
 }
 

--- a/src/service/airtablePoller.js
+++ b/src/service/airtablePoller.js
@@ -4,67 +4,75 @@ const Airtable = require('airtable');
 const ChangeDetector = require('airtable-change-detector');
 const config = require('../config');
 
-const base = new Airtable({apiKey: config.airtable.key})
-    .base(config.airtable.baseId);
 
-const airtableGatewayDetector = new ChangeDetector(
-    base(config.airtable.tableName), {
-      writeDelayMs: 100,
-      metaFieldName: 'Meta', // Defaults to `Meta`
-      lastModifiedFieldName: 'AirTable Gateway Last Modified',
-      lastProcessedFieldName: 'Airtable Gateway Last Processed',
-    },
-);
+class AirtablePoller {
+  constructor() {
+    const base = new Airtable({apiKey: config.airtable.key})
+        .base(config.airtable.baseId);
 
-module.exports = () => {
-  airtableGatewayDetector.pollWithInterval(
-      `Polling of ${config.airtable.tableName}`,
-      10000, // interval in milliseconds
-      async (recordsChanged) => {
-        const numChanges = recordsChanged.length;
-        const msg =
-        `Found ${numChanges} changes in ${config.airtable.tableName}`;
-        console.info(msg);
-        const promises = [];
-        recordsChanged.forEach((record) => {
-          if (Object.keys(record.getMeta().lastValues).length === 0) return;
-          let status;
-          const justCantArr = [
-            'In Progress - We Can’t Take Responsibility for This Anymore',
-            'EMERGENCY- Has Urgent Needs to be filled; that we cannot!',
-          ];
-          const completedArr = [
-            'Resolved - Follow up next week',
-            'Resolved - Able to Fill Need',
-            'Resolved - Cancelled',
-          ];
-          const assignedArr = [
-            'In Progress- Unable to contact',
-            'In Progress - We Take Responsibility For This',
-          ];
-          if (justCantArr.includes(record.fields.Status)) {
-            status = 'justCant';
-          } else if (completedArr.includes(record.fields.Status)) {
-            status = 'completed';
-          } else if (assignedArr.includes(record.fields.Status)) {
-            status = 'assigned';
-          } else {
-            return;
-          }
-          promises.push(axios.post(config.url.newReq, {
-            manyc: {
-              status, // justCant || completed || assigned
-              id: record.fields['Unique ID'],
-              groupClaiming:
-              record.fields['Group Claiming'] || null, // not always present
-              notes: record.fields['Note'] || null, // not always present
-            },
-          }));
-        });
+    this.airtableGatewayDetector = new ChangeDetector(
+        base(config.airtable.tableName), {
+          writeDelayMs: 100,
+          metaFieldName: 'Meta', // Defaults to `Meta`
+          lastModifiedFieldName: 'AirTable Gateway Last Modified',
+          lastProcessedFieldName: 'Airtable Gateway Last Processed',
+        },
+    );
+  }
+  async processChangedRecords(recordsChanged) {
+    const numChanges = recordsChanged.length;
+    const msg =
+      `Found ${numChanges} changes in ${config.airtable.tableName}`;
+    console.info(msg);
+    const promises = [];
+    recordsChanged.forEach((record) => {
+      if (Object.keys(record.getMeta().lastValues).length === 0) return;
+      let status;
+      const justCantArr = [
+        'In Progress - We Can’t Take Responsibility for This Anymore',
+        'EMERGENCY- Has Urgent Needs to be filled; that we cannot!',
+      ];
+      const completedArr = [
+        'Resolved - Follow up next week',
+        'Resolved - Able to Fill Need',
+        'Resolved - Cancelled',
+      ];
+      const assignedArr = [
+        'In Progress- Unable to contact',
+        'In Progress - We Take Responsibility For This',
+      ];
+      if (justCantArr.includes(record.fields.Status)) {
+        status = 'justCant';
+      } else if (completedArr.includes(record.fields.Status)) {
+        status = 'completed';
+      } else if (assignedArr.includes(record.fields.Status)) {
+        status = 'assigned';
+      } else {
+        return;
+      }
+      promises.push(axios.post(config.url.newReq, {
+        manyc: {
+          status, // justCant || completed || assigned
+          id: record.fields['Unique ID'],
+          groupClaiming:
+            record.fields['Group Claiming'] || null, // not always present
+          notes: record.fields['Note'] || null, // not always present
+        },
+      }));
+    });
 
-        // If doing many Airtable writes, be careful of 5rps rate limit
-        return Promise.all(promises);
-      },
-  );
-};
+    // If doing many Airtable writes, be careful of 5rps rate limit
+    return Promise.all(promises);
+  }
+  poll() {
+    this.airtableGatewayDetector.pollWithInterval(
+        `Polling of ${config.airtable.tableName}`,
+        10000, // interval in milliseconds
+        this.processChangedRecords);
+  }
+}
+
+const poller = new AirtablePoller();
+
+module.exports = poller;
 

--- a/test/loaders/express.test.js
+++ b/test/loaders/express.test.js
@@ -1,0 +1,19 @@
+'use strict'
+const request = require('supertest');
+const { expect } = require('chai');
+const expressLoader = require('../../src/loaders/express');
+const app = require('express')()
+
+expressLoader(app)
+
+describe('GET /', async () => {
+  it('return result 200 status', async () => {
+    const res = await request(app).get('/');
+    expect(res.status).to.equal(200);
+    expect(res.body).to.eql({});
+    expect(res.type).to.equal('text/html')
+    expect(res.text).to.include('<!doctype html>')
+    expect(res.text).to.include('MANYC Airtable-Gateway Mapping Form')
+
+  });
+});

--- a/test/loaders/express.test.js
+++ b/test/loaders/express.test.js
@@ -1,19 +1,19 @@
-'use strict'
+'use strict';
 const request = require('supertest');
-const { expect } = require('chai');
+const {expect} = require('chai');
 const expressLoader = require('../../src/loaders/express');
-const app = require('express')()
+const app = require('express')();
 
-expressLoader(app)
+expressLoader(app);
 
 describe('GET /', async () => {
   it('return result 200 status', async () => {
     const res = await request(app).get('/');
+
     expect(res.status).to.equal(200);
     expect(res.body).to.eql({});
-    expect(res.type).to.equal('text/html')
-    expect(res.text).to.include('<!doctype html>')
-    expect(res.text).to.include('MANYC Airtable-Gateway Mapping Form')
-
+    expect(res.type).to.equal('text/html');
+    expect(res.text).to.include('<!doctype html>');
+    expect(res.text).to.include('MANYC Airtable-Gateway Mapping Form');
   });
 });

--- a/test/routes/api/createRequest.test.js
+++ b/test/routes/api/createRequest.test.js
@@ -1,0 +1,45 @@
+'use strict';
+const request = require('supertest');
+const sinon = require('sinon');
+const {expect} = require('chai');
+const expressLoader = require('../../../src/loaders/express');
+const app = require('express')();
+const addAirtableToRow = require('../../../src/service/addAirTableRow');
+const config = require('../../../src/config');
+
+expressLoader(app);
+
+describe('GET /api/createRequest', async () => {
+  let stub;
+  beforeEach(() => {
+    stub = sinon.stub(addAirtableToRow, 'addAirtableRows');
+  });
+  afterEach(() => {
+    stub.restore();
+  });
+  it('return result 200 status with a descriptive message', async () => {
+    stub.resolves('');
+    const res = await request(app).post('/api/createRequest');
+
+    expect(res.status).to.equal(200);
+    expect(res.body).to.eql({});
+    expect(res.type).to.equal('text/html');
+    expect(res.text).to.equal('MANYC Airtable-Gateway Needs Request Created');
+  });
+  it('Invokes addAirtableRows', async () => {
+    const fakeBody = {use: 'me'};
+    stub.resolves('');
+
+    await request(app).post('/api/createRequest').send(fakeBody);
+
+    expect(stub.called).to.be.true;
+    expect(stub.firstCall.args[0]).to.equal(config.airtable.key);
+    expect(stub.firstCall.args[1]).to.equal(config.airtable.baseId);
+    expect(stub.firstCall.args[2]).to.equal(config.airtable.tableName);
+    expect(stub.firstCall.args[3]).to.eql([fakeBody]);
+  });
+  it('Doesn\'t crash the program on an error', async () => {
+    stub.throws(new Error('fake error yo!'));
+    await request(app).post('/api/createRequest');
+  });
+});

--- a/test/routes/api/getColumnMapping.test.js
+++ b/test/routes/api/getColumnMapping.test.js
@@ -1,0 +1,18 @@
+'use strict';
+const request = require('supertest');
+const { expect } = require('chai');
+const expressLoader = require('../../../src/loaders/express');
+const app = require('express')();
+
+expressLoader(app);
+
+describe('GET /api/getColumnMapping', async () => {
+  it('return result 200 status', async () => {
+    const res = await request(app).get('/api/getColumnMapping');
+
+    expect(res.status).to.equal(200);
+    expect(res.body).to.eql({});
+    expect(res.type).to.equal('text/html');
+    expect(res.text).to.include('Column Mapping not set yet ...');
+  });
+});

--- a/test/routes/api/getColumnMapping.test.js
+++ b/test/routes/api/getColumnMapping.test.js
@@ -1,6 +1,6 @@
 'use strict';
 const request = require('supertest');
-const { expect } = require('chai');
+const {expect} = require('chai');
 const expressLoader = require('../../../src/loaders/express');
 const app = require('express')();
 

--- a/test/routes/api/setColumnMapping.test.js
+++ b/test/routes/api/setColumnMapping.test.js
@@ -6,13 +6,13 @@ const app = require('express')();
 
 expressLoader(app);
 
-describe('GET /api/getColumnMapping', async () => {
+describe('GET /api/setColumnMapping', async () => {
   it('return result 200 status', async () => {
-    const res = await request(app).get('/api/getColumnMapping');
+    const res = await request(app).post('/api/setColumnMapping');
 
     expect(res.status).to.equal(200);
     expect(res.body).to.eql({});
     expect(res.type).to.equal('text/html');
-    expect(res.text).to.equal('Column Mapping not set yet ...');
+    expect(res.text).to.equal('MANYC Airtable-Gateway Client Mapping Set');
   });
 });

--- a/test/service/addAirTableRow.test.js
+++ b/test/service/addAirTableRow.test.js
@@ -1,0 +1,191 @@
+'use strict';
+const sinon = require('sinon');
+const {expect} = require('chai');
+const {addAirtableRows} = require('../../src/service/addAirTableRow');
+const Airtable = require('airtable');
+const config = require('../../src/config');
+
+
+describe('addAirtableRows', () => {
+  let baseStub; let createStub; let configureStub; let selectedBaseStub;
+
+  const input = [{
+    manyc: {
+      status: 1,
+      id: 2,
+      supportType: 3,
+      otherSupport: 4,
+      community: 5,
+      language: 6,
+      languageOther: 7,
+      phone: 8,
+      email: 9,
+      fullName: 10,
+      urgency: 11,
+      contactMethod: 12,
+      crossStreet: 13,
+      timestampSent: 14,
+    },
+  }, {
+    manyc: {
+      status: 15,
+      id: 16,
+      supportType: 17,
+      otherSupport: 18,
+      community: 19,
+      language: 20,
+      languageOther: 21,
+      phone: 22,
+      email: 23,
+      fullName: 24,
+      urgency: 25,
+      contactMethod: 26,
+      crossStreet: 27,
+      timestampSent: 28,
+    },
+  }];
+
+  const result1 = [{
+    fields: {
+      'Status': 1,
+      'Unique ID': 2,
+      'What type(s) of support are you seeking?': 3,
+      'If you\'re seeking other types of support, please describe.': 4,
+      'Are you, or anyone in your household in one or more of these hardest-hit groups? Please select all that apply.': 5, // eslint-disable-line max-len
+      'Language Access: is your primary language something other than English, for which you\'d need translation & interpretation support to connect to volunteers?': 6, // eslint-disable-line max-len
+      'Other language(s) spoken:': 7,
+      'Cell': 8,
+      'Email': 9,
+      'Full Name': 10,
+      'How soon do you need support?': 11,
+      'Which of these ways are best to get in touch with you?': 12,
+      'Cross Streets': 13,
+      'Dispatched Time': 14,
+    },
+  },
+  {
+    fields: {
+      'Status': 15,
+      'Unique ID': 16,
+      'What type(s) of support are you seeking?': 17,
+      'If you\'re seeking other types of support, please describe.': 18,
+      'Are you, or anyone in your household in one or more of these hardest-hit groups? Please select all that apply.': 19, // eslint-disable-line max-len
+      'Language Access: is your primary language something other than English, for which you\'d need translation & interpretation support to connect to volunteers?': 20, // eslint-disable-line max-len
+      'Other language(s) spoken:': 21,
+      'Cell': 22,
+      'Email': 23,
+      'Full Name': 24,
+      'How soon do you need support?': 25,
+      'Which of these ways are best to get in touch with you?': 26,
+      'Cross Streets': 27,
+      'Dispatched Time': 28,
+    },
+  },
+  ];
+  const mapping = {
+    status: '1',
+    id: '2',
+    supportType: '3',
+    otherSupport: '4',
+    community: '5',
+    language: '6',
+    languageOther: '7',
+    phone: '8',
+    email: '9',
+    fullName: '10',
+    urgency: '11',
+    contactMethod: '12',
+    crossStreet: '13',
+    timestampSent: '14',
+  };
+
+  const result2 = [{
+    fields: {
+      '1': 1,
+      '2': 2,
+      '3': 3,
+      '4': 4,
+      '5': 5,
+      '6': 6,
+      '7': 7,
+      '8': 8,
+      '9': 9,
+      '10': 10,
+      '11': 11,
+      '12': 12,
+      '13': 13,
+      '14': 14,
+    },
+  },
+  {
+    fields: {
+      '1': 15,
+      '2': 16,
+      '3': 17,
+      '4': 18,
+      '5': 19,
+      '6': 20,
+      '7': 21,
+      '8': 22,
+      '9': 23,
+      '10': 24,
+      '11': 25,
+      '12': 26,
+      '13': 27,
+      '14': 28,
+    },
+  },
+  ];
+  beforeEach(() => {
+    createStub = sinon.stub();
+    baseStub = sinon.stub(Airtable, 'base');
+    // createStub.resolves(recordId);
+    createStub.callsArgWith(1, undefined, undefined);
+    selectedBaseStub = sinon.stub();
+    configureStub = sinon.stub(Airtable, 'configure');
+    baseStub.returns(selectedBaseStub);
+    selectedBaseStub.returns({create: createStub});
+  });
+  afterEach(() => {
+    configureStub.restore();
+    baseStub.restore();
+  });
+  // eslint-disable-next-line max-len
+  describe('Transforms records and adds to Airtable base and returns a promise', () => {
+    it('Uses a default mapping', () => {
+      expect(addAirtableRows(
+          config.airtable.key,
+          config.airtable.baseId,
+          config.airtable.tableName,
+          input,
+      )).to.be.instanceOf(Promise);
+      expect(baseStub.firstCall.firstArg).to.equal(config.airtable.baseId);
+      expect(selectedBaseStub.firstCall.firstArg).to.equal(config.airtable
+          .tableName);
+      expect(configureStub.firstCall.firstArg).to.eql({
+        apiKey: config.airtable
+            .key,
+      });
+      expect(createStub.firstCall.args[0]).to.eql(result1);
+      expect(typeof createStub.firstCall.args[1]).to.equal('function');
+    });
+    it('Can override the default mapping', () => {
+      expect(addAirtableRows(
+          config.airtable.key,
+          config.airtable.baseId,
+          config.airtable.tableName,
+          input,
+          mapping,
+      )).to.be.instanceOf(Promise);
+      expect(baseStub.firstCall.firstArg).to.equal(config.airtable.baseId);
+      expect(selectedBaseStub.firstCall.firstArg).to.equal(config.airtable
+          .tableName);
+      expect(configureStub.firstCall.firstArg).to.eql({
+        apiKey: config.airtable
+            .key,
+      });
+      expect(createStub.firstCall.args[0]).to.eql(result2);
+      expect(typeof createStub.firstCall.args[1]).to.equal('function');
+    });
+  });
+});

--- a/test/service/airtablePoller.examples.js
+++ b/test/service/airtablePoller.examples.js
@@ -1,131 +1,132 @@
-'use strict'
-
+'use strict';
+/* eslint-disable max-len */
 module.exports = {
   newRecord: [
     {
       fields: {
         'Unique ID': 985,
-        Cell: '(516) 555-1234',
+        'Cell': '(516) 555-1234',
         'Language Access: Do you prefer to communicate in a language other than English? If yes, please choose the language below.': [
-          'recXXXXXXXXXXXXXX'
+          'recXXXXXXXXXXXXXX',
         ],
         'What type(s) of support are you seeking?': [
           'Deliver groceries or supplies to me',
-          'Pick up a prescription for me'
+          'Pick up a prescription for me',
         ],
         'Cross Streets': '120th & 7th',
         'What borough/region are you in?': 'Bronx',
         'What neighborhood?': [
-          'recxxxxxxxxxxxxx2'
+          'recxxxxxxxxxxxxx2',
         ],
         'How soon do you need support?': 'In the next few days (3 - 5 Days)',
         'Anything else you want to share about your situation at this time?': 'Pie is great',
         'Timestamp Created': '2020-05-12T00:07:49.000Z',
         'Automation Logs': 'Dispatched: 11-05-2020 08:31 PM',
-        Name: 'John',
+        'Name': 'John',
         'Full Name': 'John Doe ',
         'Dispatched Time': '2020-05-12T00:25:32.000Z',
         'Automation Updated Timestamp': '2020-05-17T11:53:51.000Z',
-        'AirTable Gateway Last Modified': '2020-05-17'
-      }
-    }
+        'AirTable Gateway Last Modified': '2020-05-17',
+      },
+    },
   ],
   twoRecords: [
     {
       id: 'recxxxxxxxxxxx',
       fields: {
         'Unique ID': 985,
-        Cell: '(516) 555-1234',
+        'Cell': '(516) 555-1234',
         'Language Access: Do you prefer to communicate in a language other than English? If yes, please choose the language below.': [
-          'recxxxxxxx1'
+          'recxxxxxxx1',
         ],
         'What type(s) of support are you seeking?': [
           'Deliver groceries or supplies to me',
-          'Pick up a prescription for me'
+          'Pick up a prescription for me',
         ],
         'Cross Streets': '120th & 7th',
         'What borough/region are you in?': 'Bronx',
         'What neighborhood?': [
-          'recxxxxxxxxx2'
+          'recxxxxxxxxx2',
         ],
         'How soon do you need support?': 'In the next few days (3 - 5 Days)',
         'Anything else you want to share about your situation at this time?': 'Pie is great',
         'Timestamp Created': '2020-05-12T00:07:49.000Z',
         'Automation Logs': 'Dispatched: 11-05-2020 08:31 PM',
-        Name: 'John',
-        Meta: '{"lastValues":{"Unique ID":985,"Cell":"(516) 555-1234","Language Access: Do you prefer to communicate in a language other than English? If yes, please choose the language below.":["recxxxxxxxxx"],"What type(s) of support are you seeking?":["Deliver groceries or supplies to me","Pick up a prescription for me"],"Cross Streets":"120th & 7th","What borough/region are you in?":"Bronx","What neighborhood?":["recxxxxxxxx"],"How soon do you need support?":"In the next few days (3 - 5 Days)","Anything else you want to share about your situation at this time?":"Pie is great","Timestamp Created":"2020-05-12T00:07:49.000Z","Automation Logs":"Dispatched: 11-05-2020 08:31 PM","Name":"John","Full Name":"John Doe","Dispatched Time":"2020-05-12T00:25:32.000Z","Automation Updated Timestamp":"2020-05-17T11:53:51.000Z","AirTable Gateway Last Modified":"2020-05-17"}}',
+        'Name': 'John',
+        'Meta': '{"lastValues":{"Unique ID":985,"Cell":"(516) 555-1234","Language Access: Do you prefer to communicate in a language other than English? If yes, please choose the language below.":["recxxxxxxxxx"],"What type(s) of support are you seeking?":["Deliver groceries or supplies to me","Pick up a prescription for me"],"Cross Streets":"120th & 7th","What borough/region are you in?":"Bronx","What neighborhood?":["recxxxxxxxx"],"How soon do you need support?":"In the next few days (3 - 5 Days)","Anything else you want to share about your situation at this time?":"Pie is great","Timestamp Created":"2020-05-12T00:07:49.000Z","Automation Logs":"Dispatched: 11-05-2020 08:31 PM","Name":"John","Full Name":"John Doe","Dispatched Time":"2020-05-12T00:25:32.000Z","Automation Updated Timestamp":"2020-05-17T11:53:51.000Z","AirTable Gateway Last Modified":"2020-05-17"}}',
         'Airtable Gateway Last Processed': '2020-05-17T11:54:13.412Z',
         'Full Name': 'John Doe ',
         'Dispatched Time': '2020-05-12T00:25:32.000Z',
         'Automation Updated Timestamp': '2020-05-17T12:10:38.000Z',
         'AirTable Gateway Last Modified': '2020-05-17',
-        Status: 'In Progress - We Take Responsibility For This'
-      }
+        'Status': 'In Progress - We Take Responsibility For This',
+      },
     },
     {
       id: 'recxxxxxxxxxxx',
       fields: {
         'Unique ID': 985,
-        Cell: '(516) 555-1234',
+        'Cell': '(516) 555-1234',
         'Language Access: Do you prefer to communicate in a language other than English? If yes, please choose the language below.': [
-          'recxxxxxxx1'
+          'recxxxxxxx1',
         ],
         'What type(s) of support are you seeking?': [
           'Deliver groceries or supplies to me',
-          'Pick up a prescription for me'
+          'Pick up a prescription for me',
         ],
         'Cross Streets': '120th & 7th',
         'What borough/region are you in?': 'Bronx',
         'What neighborhood?': [
-          'recxxxxxxxxx2'
+          'recxxxxxxxxx2',
         ],
         'How soon do you need support?': 'In the next few days (3 - 5 Days)',
         'Anything else you want to share about your situation at this time?': 'Pie is great',
         'Timestamp Created': '2020-05-12T00:07:49.000Z',
         'Automation Logs': 'Dispatched: 11-05-2020 08:31 PM',
-        Name: 'John',
-        Meta: '{"lastValues":{"Unique ID":985,"Cell":"(516) 555-1234","Language Access: Do you prefer to communicate in a language other than English? If yes, please choose the language below.":["recxxxxxxxxx"],"What type(s) of support are you seeking?":["Deliver groceries or supplies to me","Pick up a prescription for me"],"Cross Streets":"120th & 7th","What borough/region are you in?":"Bronx","What neighborhood?":["recxxxxxxxx"],"How soon do you need support?":"In the next few days (3 - 5 Days)","Anything else you want to share about your situation at this time?":"Pie is great","Timestamp Created":"2020-05-12T00:07:49.000Z","Automation Logs":"Dispatched: 11-05-2020 08:31 PM","Name":"John","Full Name":"John Doe","Dispatched Time":"2020-05-12T00:25:32.000Z","Automation Updated Timestamp":"2020-05-17T11:53:51.000Z","AirTable Gateway Last Modified":"2020-05-17"}}',
+        'Name': 'John',
+        'Meta': '{"lastValues":{"Unique ID":985,"Cell":"(516) 555-1234","Language Access: Do you prefer to communicate in a language other than English? If yes, please choose the language below.":["recxxxxxxxxx"],"What type(s) of support are you seeking?":["Deliver groceries or supplies to me","Pick up a prescription for me"],"Cross Streets":"120th & 7th","What borough/region are you in?":"Bronx","What neighborhood?":["recxxxxxxxx"],"How soon do you need support?":"In the next few days (3 - 5 Days)","Anything else you want to share about your situation at this time?":"Pie is great","Timestamp Created":"2020-05-12T00:07:49.000Z","Automation Logs":"Dispatched: 11-05-2020 08:31 PM","Name":"John","Full Name":"John Doe","Dispatched Time":"2020-05-12T00:25:32.000Z","Automation Updated Timestamp":"2020-05-17T11:53:51.000Z","AirTable Gateway Last Modified":"2020-05-17"}}',
         'Airtable Gateway Last Processed': '2020-05-17T11:54:13.412Z',
         'Full Name': 'John Doe ',
         'Dispatched Time': '2020-05-12T00:25:32.000Z',
         'Automation Updated Timestamp': '2020-05-17T12:10:38.000Z',
         'AirTable Gateway Last Modified': '2020-05-17',
-        Status: 'In Progress - We Take Responsibility For This'
-      }
-    }
+        'Status': 'In Progress - We Take Responsibility For This',
+      },
+    },
   ],
   oneRecord: [
     {
       id: 'recxxxxxxxxxxx',
       fields: {
         'Unique ID': 985,
-        Cell: '(516) 555-1234',
+        'Cell': '(516) 555-1234',
         'Language Access: Do you prefer to communicate in a language other than English? If yes, please choose the language below.': [
-          'recxxxxxxx1'
+          'recxxxxxxx1',
         ],
         'What type(s) of support are you seeking?': [
           'Deliver groceries or supplies to me',
-          'Pick up a prescription for me'
+          'Pick up a prescription for me',
         ],
         'Cross Streets': '120th & 7th',
         'What borough/region are you in?': 'Bronx',
         'What neighborhood?': [
-          'recxxxxxxxxx2'
+          'recxxxxxxxxx2',
         ],
         'How soon do you need support?': 'In the next few days (3 - 5 Days)',
         'Anything else you want to share about your situation at this time?': 'Pie is great',
         'Timestamp Created': '2020-05-12T00:07:49.000Z',
         'Automation Logs': 'Dispatched: 11-05-2020 08:31 PM',
-        Note: 'some awesome note',
-        Name: 'John',
-        Meta: '{"lastValues":{"Unique ID":985,"Cell":"(516) 555-1234","Language Access: Do you prefer to communicate in a language other than English? If yes, please choose the language below.":["recxxxxxxxxx"],"What type(s) of support are you seeking?":["Deliver groceries or supplies to me","Pick up a prescription for me"],"Cross Streets":"120th & 7th","What borough/region are you in?":"Bronx","What neighborhood?":["recxxxxxxxx"],"How soon do you need support?":"In the next few days (3 - 5 Days)","Anything else you want to share about your situation at this time?":"Pie is great","Timestamp Created":"2020-05-12T00:07:49.000Z","Automation Logs":"Dispatched: 11-05-2020 08:31 PM","Name":"John","Full Name":"John Doe","Dispatched Time":"2020-05-12T00:25:32.000Z","Automation Updated Timestamp":"2020-05-17T11:53:51.000Z","AirTable Gateway Last Modified":"2020-05-17"}}',
+        'Note': 'some awesome note',
+        'Name': 'John',
+        'Meta': '{"lastValues":{"Unique ID":985,"Cell":"(516) 555-1234","Language Access: Do you prefer to communicate in a language other than English? If yes, please choose the language below.":["recxxxxxxxxx"],"What type(s) of support are you seeking?":["Deliver groceries or supplies to me","Pick up a prescription for me"],"Cross Streets":"120th & 7th","What borough/region are you in?":"Bronx","What neighborhood?":["recxxxxxxxx"],"How soon do you need support?":"In the next few days (3 - 5 Days)","Anything else you want to share about your situation at this time?":"Pie is great","Timestamp Created":"2020-05-12T00:07:49.000Z","Automation Logs":"Dispatched: 11-05-2020 08:31 PM","Name":"John","Full Name":"John Doe","Dispatched Time":"2020-05-12T00:25:32.000Z","Automation Updated Timestamp":"2020-05-17T11:53:51.000Z","AirTable Gateway Last Modified":"2020-05-17"}}',
         'Airtable Gateway Last Processed': '2020-05-17T11:54:13.412Z',
         'Full Name': 'John Doe ',
         'Dispatched Time': '2020-05-12T00:25:32.000Z',
         'Automation Updated Timestamp': '2020-05-17T12:10:38.000Z',
         'AirTable Gateway Last Modified': '2020-05-17',
-        Status: 'In Progress - We Take Responsibility For This'
-      }
+        'Status': 'In Progress - We Take Responsibility For This',
+      },
     },
-  ]
-}
+  ],
+};
+/* eslint-enable max-len */

--- a/test/service/airtablePoller.examples.js
+++ b/test/service/airtablePoller.examples.js
@@ -1,0 +1,131 @@
+'use strict'
+
+module.exports = {
+  newRecord: [
+    {
+      fields: {
+        'Unique ID': 985,
+        Cell: '(516) 555-1234',
+        'Language Access: Do you prefer to communicate in a language other than English? If yes, please choose the language below.': [
+          'recXXXXXXXXXXXXXX'
+        ],
+        'What type(s) of support are you seeking?': [
+          'Deliver groceries or supplies to me',
+          'Pick up a prescription for me'
+        ],
+        'Cross Streets': '120th & 7th',
+        'What borough/region are you in?': 'Bronx',
+        'What neighborhood?': [
+          'recxxxxxxxxxxxxx2'
+        ],
+        'How soon do you need support?': 'In the next few days (3 - 5 Days)',
+        'Anything else you want to share about your situation at this time?': 'Pie is great',
+        'Timestamp Created': '2020-05-12T00:07:49.000Z',
+        'Automation Logs': 'Dispatched: 11-05-2020 08:31 PM',
+        Name: 'John',
+        'Full Name': 'John Doe ',
+        'Dispatched Time': '2020-05-12T00:25:32.000Z',
+        'Automation Updated Timestamp': '2020-05-17T11:53:51.000Z',
+        'AirTable Gateway Last Modified': '2020-05-17'
+      }
+    }
+  ],
+  twoRecords: [
+    {
+      id: 'recxxxxxxxxxxx',
+      fields: {
+        'Unique ID': 985,
+        Cell: '(516) 555-1234',
+        'Language Access: Do you prefer to communicate in a language other than English? If yes, please choose the language below.': [
+          'recxxxxxxx1'
+        ],
+        'What type(s) of support are you seeking?': [
+          'Deliver groceries or supplies to me',
+          'Pick up a prescription for me'
+        ],
+        'Cross Streets': '120th & 7th',
+        'What borough/region are you in?': 'Bronx',
+        'What neighborhood?': [
+          'recxxxxxxxxx2'
+        ],
+        'How soon do you need support?': 'In the next few days (3 - 5 Days)',
+        'Anything else you want to share about your situation at this time?': 'Pie is great',
+        'Timestamp Created': '2020-05-12T00:07:49.000Z',
+        'Automation Logs': 'Dispatched: 11-05-2020 08:31 PM',
+        Name: 'John',
+        Meta: '{"lastValues":{"Unique ID":985,"Cell":"(516) 555-1234","Language Access: Do you prefer to communicate in a language other than English? If yes, please choose the language below.":["recxxxxxxxxx"],"What type(s) of support are you seeking?":["Deliver groceries or supplies to me","Pick up a prescription for me"],"Cross Streets":"120th & 7th","What borough/region are you in?":"Bronx","What neighborhood?":["recxxxxxxxx"],"How soon do you need support?":"In the next few days (3 - 5 Days)","Anything else you want to share about your situation at this time?":"Pie is great","Timestamp Created":"2020-05-12T00:07:49.000Z","Automation Logs":"Dispatched: 11-05-2020 08:31 PM","Name":"John","Full Name":"John Doe","Dispatched Time":"2020-05-12T00:25:32.000Z","Automation Updated Timestamp":"2020-05-17T11:53:51.000Z","AirTable Gateway Last Modified":"2020-05-17"}}',
+        'Airtable Gateway Last Processed': '2020-05-17T11:54:13.412Z',
+        'Full Name': 'John Doe ',
+        'Dispatched Time': '2020-05-12T00:25:32.000Z',
+        'Automation Updated Timestamp': '2020-05-17T12:10:38.000Z',
+        'AirTable Gateway Last Modified': '2020-05-17',
+        Status: 'In Progress - We Take Responsibility For This'
+      }
+    },
+    {
+      id: 'recxxxxxxxxxxx',
+      fields: {
+        'Unique ID': 985,
+        Cell: '(516) 555-1234',
+        'Language Access: Do you prefer to communicate in a language other than English? If yes, please choose the language below.': [
+          'recxxxxxxx1'
+        ],
+        'What type(s) of support are you seeking?': [
+          'Deliver groceries or supplies to me',
+          'Pick up a prescription for me'
+        ],
+        'Cross Streets': '120th & 7th',
+        'What borough/region are you in?': 'Bronx',
+        'What neighborhood?': [
+          'recxxxxxxxxx2'
+        ],
+        'How soon do you need support?': 'In the next few days (3 - 5 Days)',
+        'Anything else you want to share about your situation at this time?': 'Pie is great',
+        'Timestamp Created': '2020-05-12T00:07:49.000Z',
+        'Automation Logs': 'Dispatched: 11-05-2020 08:31 PM',
+        Name: 'John',
+        Meta: '{"lastValues":{"Unique ID":985,"Cell":"(516) 555-1234","Language Access: Do you prefer to communicate in a language other than English? If yes, please choose the language below.":["recxxxxxxxxx"],"What type(s) of support are you seeking?":["Deliver groceries or supplies to me","Pick up a prescription for me"],"Cross Streets":"120th & 7th","What borough/region are you in?":"Bronx","What neighborhood?":["recxxxxxxxx"],"How soon do you need support?":"In the next few days (3 - 5 Days)","Anything else you want to share about your situation at this time?":"Pie is great","Timestamp Created":"2020-05-12T00:07:49.000Z","Automation Logs":"Dispatched: 11-05-2020 08:31 PM","Name":"John","Full Name":"John Doe","Dispatched Time":"2020-05-12T00:25:32.000Z","Automation Updated Timestamp":"2020-05-17T11:53:51.000Z","AirTable Gateway Last Modified":"2020-05-17"}}',
+        'Airtable Gateway Last Processed': '2020-05-17T11:54:13.412Z',
+        'Full Name': 'John Doe ',
+        'Dispatched Time': '2020-05-12T00:25:32.000Z',
+        'Automation Updated Timestamp': '2020-05-17T12:10:38.000Z',
+        'AirTable Gateway Last Modified': '2020-05-17',
+        Status: 'In Progress - We Take Responsibility For This'
+      }
+    }
+  ],
+  oneRecord: [
+    {
+      id: 'recxxxxxxxxxxx',
+      fields: {
+        'Unique ID': 985,
+        Cell: '(516) 555-1234',
+        'Language Access: Do you prefer to communicate in a language other than English? If yes, please choose the language below.': [
+          'recxxxxxxx1'
+        ],
+        'What type(s) of support are you seeking?': [
+          'Deliver groceries or supplies to me',
+          'Pick up a prescription for me'
+        ],
+        'Cross Streets': '120th & 7th',
+        'What borough/region are you in?': 'Bronx',
+        'What neighborhood?': [
+          'recxxxxxxxxx2'
+        ],
+        'How soon do you need support?': 'In the next few days (3 - 5 Days)',
+        'Anything else you want to share about your situation at this time?': 'Pie is great',
+        'Timestamp Created': '2020-05-12T00:07:49.000Z',
+        'Automation Logs': 'Dispatched: 11-05-2020 08:31 PM',
+        Note: 'some awesome note',
+        Name: 'John',
+        Meta: '{"lastValues":{"Unique ID":985,"Cell":"(516) 555-1234","Language Access: Do you prefer to communicate in a language other than English? If yes, please choose the language below.":["recxxxxxxxxx"],"What type(s) of support are you seeking?":["Deliver groceries or supplies to me","Pick up a prescription for me"],"Cross Streets":"120th & 7th","What borough/region are you in?":"Bronx","What neighborhood?":["recxxxxxxxx"],"How soon do you need support?":"In the next few days (3 - 5 Days)","Anything else you want to share about your situation at this time?":"Pie is great","Timestamp Created":"2020-05-12T00:07:49.000Z","Automation Logs":"Dispatched: 11-05-2020 08:31 PM","Name":"John","Full Name":"John Doe","Dispatched Time":"2020-05-12T00:25:32.000Z","Automation Updated Timestamp":"2020-05-17T11:53:51.000Z","AirTable Gateway Last Modified":"2020-05-17"}}',
+        'Airtable Gateway Last Processed': '2020-05-17T11:54:13.412Z',
+        'Full Name': 'John Doe ',
+        'Dispatched Time': '2020-05-12T00:25:32.000Z',
+        'Automation Updated Timestamp': '2020-05-17T12:10:38.000Z',
+        'AirTable Gateway Last Modified': '2020-05-17',
+        Status: 'In Progress - We Take Responsibility For This'
+      }
+    },
+  ]
+}

--- a/test/service/airtablePoller.test.js
+++ b/test/service/airtablePoller.test.js
@@ -1,0 +1,146 @@
+'use strict';
+const sinon = require('sinon');
+const { expect } = require('chai');
+const airtablePoller = require('../../src/service/airtablePoller');
+const config = require('../../src/config');
+const axios = require('axios')
+const examples = require('./airtablePoller.examples')
+
+
+describe('AirtablePoller', () => {
+  describe('ChangeDetector dependancy', () => {
+    it('Is initialiazed correctly', () => {
+      expect(airtablePoller.airtableGatewayDetector.tableName).is
+        .equal(config.airtable.tableName)
+      expect(airtablePoller.airtableGatewayDetector.writeDelayMs).is.equal(100)
+      expect(airtablePoller.airtableGatewayDetector.metaFieldName).is
+        .equal('Meta')
+      expect(airtablePoller.airtableGatewayDetector.lastModifiedFieldName).is
+        .equal('AirTable Gateway Last Modified')
+      expect(airtablePoller.airtableGatewayDetector.lastProcessedFieldName).is
+        .equal('Airtable Gateway Last Processed')
+
+    });
+    describe('poll', () => {
+      let stub;
+      beforeEach(() => {
+        stub = sinon.stub(
+          airtablePoller.airtableGatewayDetector, 'pollWithInterval'
+        )
+      });
+      afterEach(() => {
+        stub.restore()
+      });
+      it('Starts airtable gateway detector polling', () => {
+        airtablePoller.poll()
+        expect(stub.calledOnce).to.be.true
+        expect(stub.firstCall.args[0]).to
+          .equal(`Polling of ${config.airtable.tableName}`)
+        expect(stub.firstCall.args[1]).to.equal(10000)
+        expect(typeof stub.firstCall.args[2]).to.equal('function')
+        expect(stub.firstCall.args[2].name).to.equal('processChangedRecords')
+      });
+    });
+    describe('processChangedRecords', () => {
+      let stub;
+      beforeEach(() => {
+        stub = sinon.stub(axios, 'post')
+      });
+      afterEach(() => {
+        stub.restore()
+      });
+      it('Skips mever before processed records', () => {
+        examples.newRecord[0].getMeta = sinon.stub()
+        examples.newRecord[0].getMeta.returns({ lastValues: [] })
+        airtablePoller.processChangedRecords(examples.newRecord)
+        expect(stub.notCalled).to.be.true
+      });
+      it('Handles multiple records', () => {
+        examples.twoRecords[0].getMeta = sinon.stub()
+        examples.twoRecords[0].getMeta.returns({ lastValues: [1, 2] })
+        examples.twoRecords[1].getMeta = sinon.stub()
+        examples.twoRecords[1].getMeta.returns({ lastValues: [1, 2] })
+        airtablePoller.processChangedRecords(examples.twoRecords)
+        expect(stub.calledTwice).to.be.true
+      });
+      describe("Categorizes statuses and sends a 'Groups Update MANYC record'", () => {
+        const updateObj = {
+          manyc: {
+            status: undefined,
+            id: 985,
+            groupClaiming: null,
+            notes: 'some awesome note'
+          },
+        }
+        beforeEach(() => {
+          examples.oneRecord[0].getMeta = sinon.stub().returns({
+            lastValues: [1, 2]
+          })
+        });
+        it('Skips new status', () => {
+          examples.oneRecord[0].fields.Status = "New"
+          airtablePoller.processChangedRecords(examples.oneRecord)
+          expect(stub.notCalled).to.be.true
+        });
+        it('Skips unkown status', () => {
+          examples.oneRecord[0].fields.Status = "giberish"
+          airtablePoller.processChangedRecords(examples.oneRecord)
+          expect(stub.notCalled).to.be.true
+        });
+        it('Handles status "In Progress - We Can’t Take Responsibility for This Anymore"', () => {
+          updateObj.manyc.status = 'justCant'
+          examples.oneRecord[0].fields.Status =
+            "In Progress - We Can’t Take Responsibility for This Anymore"
+          airtablePoller.processChangedRecords(examples.oneRecord)
+          expect(stub.firstCall.args[0]).to.equal(config.url.newReq)
+          expect(stub.firstCall.args[1]).to.eql(updateObj)
+        });
+        it('Handles status "EMERGENCY- Has Urgent Needs to be filled; that we cannot!"', () => {
+          updateObj.manyc.status = 'justCant'
+          examples.oneRecord[0].fields.Status =
+            "EMERGENCY- Has Urgent Needs to be filled; that we cannot!"
+          airtablePoller.processChangedRecords(examples.oneRecord)
+          expect(stub.firstCall.args[0]).to.equal(config.url.newReq)
+          expect(stub.firstCall.args[1]).to.eql(updateObj)
+        });
+        it('Handles status "Resolved - Follow up next week"', () => {
+          updateObj.manyc.status = 'completed'
+          examples.oneRecord[0].fields.Status = "Resolved - Follow up next week"
+          airtablePoller.processChangedRecords(examples.oneRecord)
+          expect(stub.firstCall.args[0]).to.equal(config.url.newReq)
+          expect(stub.firstCall.args[1]).to.eql(updateObj)
+        });
+        it('Handles status "Resolved - Able to Fill Need"', () => {
+          updateObj.manyc.status = 'completed'
+          examples.oneRecord[0].fields.Status = "Resolved - Able to Fill Need"
+          airtablePoller.processChangedRecords(examples.oneRecord)
+          expect(stub.firstCall.args[0]).to.equal(config.url.newReq)
+          expect(stub.firstCall.args[1]).to.eql(updateObj)
+        });
+        it('Handles status "Resolved - Cancelled"', () => {
+          updateObj.manyc.status = 'completed'
+          examples.oneRecord[0].fields.Status = "Resolved - Cancelled"
+          airtablePoller.processChangedRecords(examples.oneRecord)
+          expect(stub.firstCall.args[0]).to.equal(config.url.newReq)
+          expect(stub.firstCall.args[1]).to.eql(updateObj)
+        });
+        it('Handles status "In Progress- Unable to contact"', () => {
+          updateObj.manyc.status = 'assigned'
+          examples.oneRecord[0].fields.Status = "In Progress- Unable to contact"
+          airtablePoller.processChangedRecords(examples.oneRecord)
+          expect(stub.firstCall.args[0]).to.equal(config.url.newReq)
+          expect(stub.firstCall.args[1]).to.eql(updateObj)
+        });
+        it('Handles status "In Progress - We Take Responsibility For This"',
+          () => {
+            updateObj.manyc.status = 'assigned'
+            examples.oneRecord[0].fields.Status =
+              "In Progress - We Take Responsibility For This"
+            airtablePoller.processChangedRecords(examples.oneRecord)
+            expect(stub.firstCall.args[0]).to.equal(config.url.newReq)
+            expect(stub.firstCall.args[1]).to.eql(updateObj)
+          });
+      })
+    });
+  });
+});

--- a/test/service/airtablePoller.test.js
+++ b/test/service/airtablePoller.test.js
@@ -1,146 +1,150 @@
 'use strict';
 const sinon = require('sinon');
-const { expect } = require('chai');
+const {expect} = require('chai');
 const airtablePoller = require('../../src/service/airtablePoller');
 const config = require('../../src/config');
-const axios = require('axios')
-const examples = require('./airtablePoller.examples')
+const axios = require('axios');
+const examples = require('./airtablePoller.examples');
 
 
 describe('AirtablePoller', () => {
   describe('ChangeDetector dependancy', () => {
     it('Is initialiazed correctly', () => {
       expect(airtablePoller.airtableGatewayDetector.tableName).is
-        .equal(config.airtable.tableName)
-      expect(airtablePoller.airtableGatewayDetector.writeDelayMs).is.equal(100)
+          .equal(config.airtable.tableName);
+      expect(airtablePoller.airtableGatewayDetector.writeDelayMs).is.equal(100);
       expect(airtablePoller.airtableGatewayDetector.metaFieldName).is
-        .equal('Meta')
+          .equal('Meta');
       expect(airtablePoller.airtableGatewayDetector.lastModifiedFieldName).is
-        .equal('AirTable Gateway Last Modified')
+          .equal('AirTable Gateway Last Modified');
       expect(airtablePoller.airtableGatewayDetector.lastProcessedFieldName).is
-        .equal('Airtable Gateway Last Processed')
-
+          .equal('Airtable Gateway Last Processed');
     });
     describe('poll', () => {
       let stub;
       beforeEach(() => {
         stub = sinon.stub(
-          airtablePoller.airtableGatewayDetector, 'pollWithInterval'
-        )
+            airtablePoller.airtableGatewayDetector, 'pollWithInterval',
+        );
       });
       afterEach(() => {
-        stub.restore()
+        stub.restore();
       });
       it('Starts airtable gateway detector polling', () => {
-        airtablePoller.poll()
-        expect(stub.calledOnce).to.be.true
+        airtablePoller.poll();
+        expect(stub.calledOnce).to.be.true;
         expect(stub.firstCall.args[0]).to
-          .equal(`Polling of ${config.airtable.tableName}`)
-        expect(stub.firstCall.args[1]).to.equal(10000)
-        expect(typeof stub.firstCall.args[2]).to.equal('function')
-        expect(stub.firstCall.args[2].name).to.equal('processChangedRecords')
+            .equal(`Polling of ${config.airtable.tableName}`);
+        expect(stub.firstCall.args[1]).to.equal(10000);
+        expect(typeof stub.firstCall.args[2]).to.equal('function');
+        expect(stub.firstCall.args[2].name).to.equal('processChangedRecords');
       });
     });
     describe('processChangedRecords', () => {
       let stub;
       beforeEach(() => {
-        stub = sinon.stub(axios, 'post')
+        stub = sinon.stub(axios, 'post');
       });
       afterEach(() => {
-        stub.restore()
+        stub.restore();
       });
       it('Skips mever before processed records', () => {
-        examples.newRecord[0].getMeta = sinon.stub()
-        examples.newRecord[0].getMeta.returns({ lastValues: [] })
-        airtablePoller.processChangedRecords(examples.newRecord)
-        expect(stub.notCalled).to.be.true
+        examples.newRecord[0].getMeta = sinon.stub();
+        examples.newRecord[0].getMeta.returns({lastValues: []});
+        airtablePoller.processChangedRecords(examples.newRecord);
+        expect(stub.notCalled).to.be.true;
       });
       it('Handles multiple records', () => {
-        examples.twoRecords[0].getMeta = sinon.stub()
-        examples.twoRecords[0].getMeta.returns({ lastValues: [1, 2] })
-        examples.twoRecords[1].getMeta = sinon.stub()
-        examples.twoRecords[1].getMeta.returns({ lastValues: [1, 2] })
-        airtablePoller.processChangedRecords(examples.twoRecords)
-        expect(stub.calledTwice).to.be.true
+        examples.twoRecords[0].getMeta = sinon.stub();
+        examples.twoRecords[0].getMeta.returns({lastValues: [1, 2]});
+        examples.twoRecords[1].getMeta = sinon.stub();
+        examples.twoRecords[1].getMeta.returns({lastValues: [1, 2]});
+        airtablePoller.processChangedRecords(examples.twoRecords);
+        expect(stub.calledTwice).to.be.true;
       });
-      describe("Categorizes statuses and sends a 'Groups Update MANYC record'", () => {
+      // eslint-disable-next-line max-len
+      describe('Categorizes statuses and sends a \'Groups Update MANYC record\'', () => {
         const updateObj = {
           manyc: {
             status: undefined,
             id: 985,
             groupClaiming: null,
-            notes: 'some awesome note'
+            notes: 'some awesome note',
           },
-        }
+        };
         beforeEach(() => {
           examples.oneRecord[0].getMeta = sinon.stub().returns({
-            lastValues: [1, 2]
-          })
+            lastValues: [1, 2],
+          });
         });
         it('Skips new status', () => {
-          examples.oneRecord[0].fields.Status = "New"
-          airtablePoller.processChangedRecords(examples.oneRecord)
-          expect(stub.notCalled).to.be.true
+          examples.oneRecord[0].fields.Status = 'New';
+          airtablePoller.processChangedRecords(examples.oneRecord);
+          expect(stub.notCalled).to.be.true;
         });
         it('Skips unkown status', () => {
-          examples.oneRecord[0].fields.Status = "giberish"
-          airtablePoller.processChangedRecords(examples.oneRecord)
-          expect(stub.notCalled).to.be.true
+          examples.oneRecord[0].fields.Status = 'giberish';
+          airtablePoller.processChangedRecords(examples.oneRecord);
+          expect(stub.notCalled).to.be.true;
         });
+        // eslint-disable-next-line max-len
         it('Handles status "In Progress - We Can’t Take Responsibility for This Anymore"', () => {
-          updateObj.manyc.status = 'justCant'
+          updateObj.manyc.status = 'justCant';
           examples.oneRecord[0].fields.Status =
-            "In Progress - We Can’t Take Responsibility for This Anymore"
-          airtablePoller.processChangedRecords(examples.oneRecord)
-          expect(stub.firstCall.args[0]).to.equal(config.url.newReq)
-          expect(stub.firstCall.args[1]).to.eql(updateObj)
+            'In Progress - We Can’t Take Responsibility for This Anymore';
+          airtablePoller.processChangedRecords(examples.oneRecord);
+          expect(stub.firstCall.args[0]).to.equal(config.url.newReq);
+          expect(stub.firstCall.args[1]).to.eql(updateObj);
         });
+        // eslint-disable-next-line max-len
         it('Handles status "EMERGENCY- Has Urgent Needs to be filled; that we cannot!"', () => {
-          updateObj.manyc.status = 'justCant'
+          updateObj.manyc.status = 'justCant';
           examples.oneRecord[0].fields.Status =
-            "EMERGENCY- Has Urgent Needs to be filled; that we cannot!"
-          airtablePoller.processChangedRecords(examples.oneRecord)
-          expect(stub.firstCall.args[0]).to.equal(config.url.newReq)
-          expect(stub.firstCall.args[1]).to.eql(updateObj)
+            'EMERGENCY- Has Urgent Needs to be filled; that we cannot!';
+          airtablePoller.processChangedRecords(examples.oneRecord);
+          expect(stub.firstCall.args[0]).to.equal(config.url.newReq);
+          expect(stub.firstCall.args[1]).to.eql(updateObj);
         });
         it('Handles status "Resolved - Follow up next week"', () => {
-          updateObj.manyc.status = 'completed'
-          examples.oneRecord[0].fields.Status = "Resolved - Follow up next week"
-          airtablePoller.processChangedRecords(examples.oneRecord)
-          expect(stub.firstCall.args[0]).to.equal(config.url.newReq)
-          expect(stub.firstCall.args[1]).to.eql(updateObj)
+          updateObj.manyc.status = 'completed';
+          examples.oneRecord[0].fields.Status =
+            'Resolved - Follow up next week';
+          airtablePoller.processChangedRecords(examples.oneRecord);
+          expect(stub.firstCall.args[0]).to.equal(config.url.newReq);
+          expect(stub.firstCall.args[1]).to.eql(updateObj);
         });
         it('Handles status "Resolved - Able to Fill Need"', () => {
-          updateObj.manyc.status = 'completed'
-          examples.oneRecord[0].fields.Status = "Resolved - Able to Fill Need"
-          airtablePoller.processChangedRecords(examples.oneRecord)
-          expect(stub.firstCall.args[0]).to.equal(config.url.newReq)
-          expect(stub.firstCall.args[1]).to.eql(updateObj)
+          updateObj.manyc.status = 'completed';
+          examples.oneRecord[0].fields.Status = 'Resolved - Able to Fill Need';
+          airtablePoller.processChangedRecords(examples.oneRecord);
+          expect(stub.firstCall.args[0]).to.equal(config.url.newReq);
+          expect(stub.firstCall.args[1]).to.eql(updateObj);
         });
         it('Handles status "Resolved - Cancelled"', () => {
-          updateObj.manyc.status = 'completed'
-          examples.oneRecord[0].fields.Status = "Resolved - Cancelled"
-          airtablePoller.processChangedRecords(examples.oneRecord)
-          expect(stub.firstCall.args[0]).to.equal(config.url.newReq)
-          expect(stub.firstCall.args[1]).to.eql(updateObj)
+          updateObj.manyc.status = 'completed';
+          examples.oneRecord[0].fields.Status = 'Resolved - Cancelled';
+          airtablePoller.processChangedRecords(examples.oneRecord);
+          expect(stub.firstCall.args[0]).to.equal(config.url.newReq);
+          expect(stub.firstCall.args[1]).to.eql(updateObj);
         });
         it('Handles status "In Progress- Unable to contact"', () => {
-          updateObj.manyc.status = 'assigned'
-          examples.oneRecord[0].fields.Status = "In Progress- Unable to contact"
-          airtablePoller.processChangedRecords(examples.oneRecord)
-          expect(stub.firstCall.args[0]).to.equal(config.url.newReq)
-          expect(stub.firstCall.args[1]).to.eql(updateObj)
+          updateObj.manyc.status = 'assigned';
+          examples.oneRecord[0].fields.Status =
+            'In Progress- Unable to contact';
+          airtablePoller.processChangedRecords(examples.oneRecord);
+          expect(stub.firstCall.args[0]).to.equal(config.url.newReq);
+          expect(stub.firstCall.args[1]).to.eql(updateObj);
         });
         it('Handles status "In Progress - We Take Responsibility For This"',
-          () => {
-            updateObj.manyc.status = 'assigned'
-            examples.oneRecord[0].fields.Status =
-              "In Progress - We Take Responsibility For This"
-            airtablePoller.processChangedRecords(examples.oneRecord)
-            expect(stub.firstCall.args[0]).to.equal(config.url.newReq)
-            expect(stub.firstCall.args[1]).to.eql(updateObj)
-          });
-      })
+            () => {
+              updateObj.manyc.status = 'assigned';
+              examples.oneRecord[0].fields.Status =
+              'In Progress - We Take Responsibility For This';
+              airtablePoller.processChangedRecords(examples.oneRecord);
+              expect(stub.firstCall.args[0]).to.equal(config.url.newReq);
+              expect(stub.firstCall.args[1]).to.eql(updateObj);
+            });
+      });
     });
   });
 });


### PR DESCRIPTION
1. Install nyc (Instanbul) as dev-dependency
   * We will use this to find gaps in our testing
   1. Added a 'coverage' script to package.json
      1. This will generate a console and HTML report (It'll open the HTML report)
   2. Updated .gitignore to ignore nyc files
2. Add tests for 
   1. The / route
   2. The /api/createRequest route
      1. Refactored addAirTableRow for testability
      2. Refactored createRequest for testability
      3. Added 'use strict' to createRequest for testability
      4. Fixed reference error caused by 'use strict'
   3. The /api/getColumnMapping route
   4. The /api/setColumnMapping route
   5.  addAirTableRow
   6. airtablePoller
      1. Refactored airtablePoller into a class for easier testing
3. Add a package.json script `lint-fix` to run `eslint . --fix`
4. Changed an eslint rule `require-jsdoc` from error to warning
5. Ran lint-fix and cleaned up
6. Add GitHub Actions to run tests before a PR can be merged.




This PR resolves #14 