### PR TITLE
fix: Fix heroku deployment button and vars

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -18,7 +18,7 @@ Follow the steps below, but here is a video, with covering the first 9 steps if 
    3. MANY Delete Request URL
 2. Add to your list of statuses a status 'Recalled' this will be used when MANYC triggers a cancel of a request.
 3. Click this button, and continue reading.
-   [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+   [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/MutualAidNYC/airtable_gateway)
 4. Give your app a unique Heroku name, the name itself doesn't have an effect.
 5. Choose the 'App Owner'
 6. For region, 'United States' is sufficient.

--- a/app.json
+++ b/app.json
@@ -25,11 +25,11 @@
     },
     "MANYC_UPDATE_REQ_URL": {
       "description": "This will be provided to you by MANYC",
-      "required": true
+      "required": false
     },
     "MANYC_DELETE_REQ_URL": {
       "description": "This will be provided to you by MANYC",
-      "required": true
+      "required": false
     },
     "FIELD_MAP_STATUS": {
       "description": "Your status field",


### PR DESCRIPTION
Heroku for some reason isn't picking up the app.json file, so, i made
the button be explicit vs implicit.

We are not yet using two of the 3 URLs, making two optional.

Noticed that the used url, is labeled incorrectly, will make a issue
for it to be fixed.